### PR TITLE
Add E2EDiagnosticSetting structure and api to get/set E2EDiagnosticSetting in registry

### DIFF
--- a/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/HttpRegistryManager.cs
@@ -780,7 +780,7 @@ namespace Microsoft.Azure.Devices
             var settingJson = JsonConvert.SerializeObject(setting);
             twin.Properties.Desired = new TwinCollection(settingJson);
             twin.ETag = etag;
-            var twinResult = await UpdateTwinAsync(deviceId, twin, etag);
+            var twinResult = await UpdateTwinAsync(deviceId, twin, etag, cancellationToken);
             var updatedDiagnosticSetting = JsonConvert.DeserializeObject<E2EDiagnosticSetting>(twinResult.Properties.Desired.ToJson());
             return updatedDiagnosticSetting;
         }

--- a/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -641,7 +641,7 @@ namespace Microsoft.Azure.Devices
         /// <param name="deviceId">Device Id</param>
         /// <param name="setting"><see cref="E2EDiagnosticSetting"/></param>
         /// <param name="etag">Device ETag</param>
-        /// <returns>echoes back the E2EDiagnosticSetting object</returns>
+        /// <returns>Echoes back the E2EDiagnosticSetting object</returns>
         public abstract Task<E2EDiagnosticSetting> UpdateE2EDiagnosticSettingAsync(string deviceId, E2EDiagnosticSetting setting, string etag);
 
         /// <summary>
@@ -651,16 +651,16 @@ namespace Microsoft.Azure.Devices
         /// <param name="setting"><see cref="E2EDiagnosticSetting"/></param>
         /// <param name="etag">Device ETag</param>
         /// <param name="cancellationToken">
-        /// The token which allows the the operation to be cancelled.
+        /// The token which allows the operation to be cancelled.
         /// </param>
-        /// <returns>echoes back the E2EDiagnosticSetting object</returns>
+        /// <returns>Echoes back the E2EDiagnosticSetting object</returns>
         public abstract Task<E2EDiagnosticSetting> UpdateE2EDiagnosticSettingAsync(string deviceId, E2EDiagnosticSetting setting, string etag, CancellationToken cancellationToken);
 
         /// <summary>
         /// Get the diagnostic settings
         /// </summary>
         /// <param name="deviceId">Device Id</param>
-        /// <returns>the desired E2EDiagnosticSetting object</returns>
+        /// <returns>Desired E2EDiagnosticSetting object</returns>
         public abstract Task<E2EDiagnosticSetting> GetE2EDiagnosticSettingAsync(string deviceId);
     }
 }

--- a/service/Microsoft.Azure.Devices/RegistryManager.cs
+++ b/service/Microsoft.Azure.Devices/RegistryManager.cs
@@ -634,5 +634,33 @@ namespace Microsoft.Azure.Devices
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Updated Twin instance</returns>
         public abstract Task<Twin> ReplaceTwinAsync(string deviceId, string newTwinJson, string etag, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Update the diagnostic settings
+        /// </summary>
+        /// <param name="deviceId">Device Id</param>
+        /// <param name="setting"><see cref="E2EDiagnosticSetting"/></param>
+        /// <param name="etag">Device ETag</param>
+        /// <returns>echoes back the E2EDiagnosticSetting object</returns>
+        public abstract Task<E2EDiagnosticSetting> UpdateE2EDiagnosticSettingAsync(string deviceId, E2EDiagnosticSetting setting, string etag);
+
+        /// <summary>
+        /// Update the diagnostic settings
+        /// </summary>
+        /// <param name="deviceId">Device Id</param>
+        /// <param name="setting"><see cref="E2EDiagnosticSetting"/></param>
+        /// <param name="etag">Device ETag</param>
+        /// <param name="cancellationToken">
+        /// The token which allows the the operation to be cancelled.
+        /// </param>
+        /// <returns>echoes back the E2EDiagnosticSetting object</returns>
+        public abstract Task<E2EDiagnosticSetting> UpdateE2EDiagnosticSettingAsync(string deviceId, E2EDiagnosticSetting setting, string etag, CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Get the diagnostic settings
+        /// </summary>
+        /// <param name="deviceId">Device Id</param>
+        /// <returns>the desired E2EDiagnosticSetting object</returns>
+        public abstract Task<E2EDiagnosticSetting> GetE2EDiagnosticSettingAsync(string deviceId);
     }
 }

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
@@ -941,6 +941,76 @@ namespace Microsoft.Azure.Devices.Api.Test
         [TestMethod]
         [TestCategory("CIT")]
         [TestCategory("API")]
+        public async Task UpdateE2EDiagnosticSettingAsyncTest()
+        {
+            var settingToReturn = new E2EDiagnosticSetting(50);
+            var twin = new Twin("abcd");
+            twin.Properties.Desired = new TwinCollection("{__e2e_diag_sample_rate:50}");
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(restOp => restOp.PatchAsync<Twin, Twin>(It.IsAny<Uri>(), It.IsAny<Twin>(), It.IsAny<string>(), It.IsAny<PutOperationType>(), It.IsAny<IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(), It.IsAny<CancellationToken>())).ReturnsAsync(twin);
+
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            var returnedSetting = await registryManager.UpdateE2EDiagnosticSettingAsync("abcd", settingToReturn, "*");
+            Assert.AreEqual(settingToReturn.SamplingRate, returnedSetting.SamplingRate);
+            restOpMock.VerifyAll();
+        }
+
+        [ExpectedException(typeof(ArgumentNullException))]
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public async Task UpdateE2EDiagnosticSettingWithNullSettingTest()
+        {
+            var restOpMock = new Mock<IHttpClientHelper>();
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            await registryManager.UpdateE2EDiagnosticSettingAsync("abcd", null, "*");
+            Assert.Fail("UpdateE2EDiagnosticSetting api did not throw exception when the setting was null.");
+        }
+
+        [ExpectedException(typeof(ArgumentNullException))]
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public async Task UpdateE2EDiagnosticSettingWithEmptyDeviceIdTest()
+        {
+            var settingToReturn = new E2EDiagnosticSetting(50);
+            var restOpMock = new Mock<IHttpClientHelper>();
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            await registryManager.UpdateE2EDiagnosticSettingAsync("", settingToReturn, "*");
+            Assert.Fail("UpdateE2EDiagnosticSetting api did not throw exception when the deviceId was empty.");
+        }
+
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public async Task GetE2EDiagnosticSettingAsyncTest()
+        {
+            var twin = new Twin("abcd");
+            twin.Properties.Desired = new TwinCollection("{__e2e_diag_sample_rate:50}");
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(restOp => restOp.GetAsync<Twin>(It.IsAny<Uri>(), It.IsAny<Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(), null, It.IsAny<Boolean>(), It.IsAny<CancellationToken>())).ReturnsAsync(twin);
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            var setting = await registryManager.GetE2EDiagnosticSettingAsync("abc");
+            Assert.AreEqual(setting.SamplingRate, 50);
+        }
+
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
+        public async Task GetE2EDiagnosticSettingAsyncWithNullResultTest()
+        {
+            var twin = new Twin("abcd");
+            twin.Properties.Desired = new TwinCollection("{}");
+            var restOpMock = new Mock<IHttpClientHelper>();
+            restOpMock.Setup(restOp => restOp.GetAsync<Twin>(It.IsAny<Uri>(), It.IsAny<Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(), null, It.IsAny<Boolean>(), It.IsAny<CancellationToken>())).ReturnsAsync(twin);
+            var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);
+            var setting = await registryManager.GetE2EDiagnosticSettingAsync("abc");
+            Assert.IsNull(setting);
+        }
+
+        [TestMethod]
+        [TestCategory("CIT")]
+        [TestCategory("API")]
         public void DisposeTest()
         {
             var restOpMock = new Mock<IHttpClientHelper>();

--- a/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
+++ b/service/Microsoft.Azure.Devices/test/Microsoft.Azure.Devices.Api.Test/RegistryManagerTests.cs
@@ -945,7 +945,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         {
             var settingToReturn = new E2EDiagnosticSetting(50);
             var twin = new Twin("abcd");
-            twin.Properties.Desired = new TwinCollection("{__e2e_diag_sample_rate:50}");
+            twin.Properties.Desired = new TwinCollection("{__e2e_diag_sample_rate: 50}");
             var restOpMock = new Mock<IHttpClientHelper>();
             restOpMock.Setup(restOp => restOp.PatchAsync<Twin, Twin>(It.IsAny<Uri>(), It.IsAny<Twin>(), It.IsAny<string>(), It.IsAny<PutOperationType>(), It.IsAny<IDictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(), It.IsAny<CancellationToken>())).ReturnsAsync(twin);
 
@@ -986,7 +986,7 @@ namespace Microsoft.Azure.Devices.Api.Test
         public async Task GetE2EDiagnosticSettingAsyncTest()
         {
             var twin = new Twin("abcd");
-            twin.Properties.Desired = new TwinCollection("{__e2e_diag_sample_rate:50}");
+            twin.Properties.Desired = new TwinCollection("{__e2e_diag_sample_rate: 50}");
             var restOpMock = new Mock<IHttpClientHelper>();
             restOpMock.Setup(restOp => restOp.GetAsync<Twin>(It.IsAny<Uri>(), It.IsAny<Dictionary<HttpStatusCode, Func<HttpResponseMessage, Task<Exception>>>>(), null, It.IsAny<Boolean>(), It.IsAny<CancellationToken>())).ReturnsAsync(twin);
             var registryManager = new HttpRegistryManager(restOpMock.Object, IotHubName);

--- a/shared/Microsoft.Azure.Devices.Shared/E2EDiagnosticSetting.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/E2EDiagnosticSetting.cs
@@ -36,7 +36,7 @@ namespace Microsoft.Azure.Devices.Shared
             {
                 if (value < 0 || value > 100)
                 {
-                    throw new ArgumentException("Sampling rate should between [0,100]");
+                    throw new ArgumentException("The range of diagnostic sampling percentage should be between [0,100].");
                 }
                 _samplingRate = value;
             }

--- a/shared/Microsoft.Azure.Devices.Shared/E2EDiagnosticSetting.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/E2EDiagnosticSetting.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    using System;
+    using Newtonsoft.Json;
+
+    /// <summary>
+    /// E2EDiagnosticSetting Representation
+    /// </summary>
+    [JsonConverter(typeof(E2EDiagnosticSettingJsonConverter))]
+    public class E2EDiagnosticSetting
+    {
+        /// <summary>
+        /// Creates an instance of <see cref="E2EDiagnosticSetting"/>
+        /// </summary>
+        /// <param name="samplingRate">Sampling Rate</param>
+        public E2EDiagnosticSetting(int samplingRate = 0)
+        {
+            SamplingRate = samplingRate;
+        }
+
+        private int _samplingRate;
+
+        /// <summary>
+        /// Gets and sets the <see cref="E2EDiagnosticSetting"/> Sampling Rate.
+        /// </summary>
+        public int SamplingRate
+        {
+            get
+            {
+                return _samplingRate;
+            }
+            set
+            {
+                if (value < 0 || value > 100)
+                {
+                    throw new ArgumentException("Sampling rate should between [0,100]");
+                }
+                _samplingRate = value;
+            }
+        }
+    }
+}

--- a/shared/Microsoft.Azure.Devices.Shared/E2EDiagnosticSettingJsonConverter.cs
+++ b/shared/Microsoft.Azure.Devices.Shared/E2EDiagnosticSettingJsonConverter.cs
@@ -1,0 +1,89 @@
+﻿// Copyright (c) Microsoft. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
+namespace Microsoft.Azure.Devices.Shared
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Reflection;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+
+    /// <summary>
+    /// Converts <see cref="E2EDiagnosticSetting"/> to Json
+    /// </summary>
+    public sealed class E2EDiagnosticSettingJsonConverter : JsonConverter
+    {
+        const string SamplingPercentageJsonTag = "__e2e_diag_sample_rate";
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            if (value == null)
+            {
+                return;
+            }
+
+            E2EDiagnosticSetting e2eDiagnosticSetting = value as E2EDiagnosticSetting;
+
+            if (e2eDiagnosticSetting == null)
+            {
+                throw new InvalidOperationException("Object passed is not of type E2EDiagnostic.");
+            }
+
+            writer.WriteStartObject();
+
+            writer.WritePropertyName(SamplingPercentageJsonTag);
+            writer.WriteValue(e2eDiagnosticSetting.SamplingRate);
+            
+            writer.WriteEndObject();
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            E2EDiagnosticSetting e2eDiagnosticSetting = null;
+
+            if (reader.TokenType != JsonToken.StartObject)
+            {
+                return null;
+            }
+
+            while (reader.Read())
+            {
+                if (reader.TokenType == JsonToken.EndObject)
+                {
+                    break;
+                }
+
+                if (reader.TokenType != JsonToken.PropertyName)
+                {
+                    continue;
+                }
+
+                string propertyName = reader.Value as string;
+                reader.Read();
+
+                switch (propertyName)
+                {
+                    case SamplingPercentageJsonTag:
+                        int updatedIntegerValue;
+                        if (reader.Value != null && Int32.TryParse(reader.Value.ToString(), out updatedIntegerValue))
+                        {
+                            e2eDiagnosticSetting = new E2EDiagnosticSetting(updatedIntegerValue);
+                        }
+                        break;
+                    default:
+                        reader.Skip();
+                        break;
+                }
+            }
+
+            return e2eDiagnosticSetting;
+        }
+
+        public override bool CanRead => true;
+
+        public override bool CanWrite => true;
+
+        public override bool CanConvert(Type objectType) => typeof(E2EDiagnosticSetting).GetTypeInfo().IsAssignableFrom(objectType.GetTypeInfo());
+    }
+}

--- a/shared/Microsoft.Azure.Devices.Shared/Microsoft.Azure.Devices.Shared.csproj
+++ b/shared/Microsoft.Azure.Devices.Shared/Microsoft.Azure.Devices.Shared.csproj
@@ -53,6 +53,8 @@
     <Compile Include="Common\Extensions\StringFormattingExtensions.cs" />
     <Compile Include="DeviceConnectionState.cs" />
     <Compile Include="DeviceStatus.cs" />
+    <Compile Include="E2EDiagnosticSetting.cs" />
+    <Compile Include="E2EDiagnosticSettingJsonConverter.cs" />
     <Compile Include="ETagHolder.cs" />
     <Compile Include="IETagHolder.cs" />
     <Compile Include="Metadata.cs" />


### PR DESCRIPTION
<!--
Thank you for helping us improve the Azure IoT C SDK!

Here's a little checklist of things that will help it make its way to the repository: Note that you don't have to check all the boxes, we can help you with that. 
This being said, the more you do, the quicker it'll go through our gated build! 
--> 

# Checklist
- [ ] I have read the [contribution guidelines] (https://github.com/Azure/azure-iot-sdk-c/blob/master/.github/CONTRIBUTING.md).
- [ ] I added or modified the existing tests to cover the change (we do not allow our test coverage to go down).
- If this is a modification that impacts the behavior of a public API
  - [ ] I edited the corresponding document in the `devdoc` folder and added or modified requirements.
- I submitted this PR against the correct branch: 
  - [ ] This pull-request is submitted against the `master` branch. 

# Reference/Link to the issue solved with this PR (if any)

# Description of the problem
<!-- Please be as precise as possible: what issue you experienced, how often... -->

# Description of the solution
<!-- How you solved the issue and the other things you considered and maybe rejected --> 